### PR TITLE
add numberwidth

### DIFF
--- a/src/commands.json
+++ b/src/commands.json
@@ -4,6 +4,10 @@
     "description": "Show absolute line numbers on the left. Like in the code editor on the right)"
   },
   {
+    "command": "set numberwidth=3",
+    "description": "Sets width of the 'gutter' column used for numbering to 3"
+  },
+  {
     "command": "set relativenumber",
     "description": "Show relative line numbers on the left. These change based upon where your cursor is."
   },

--- a/src/commands.json
+++ b/src/commands.json
@@ -5,7 +5,7 @@
   },
   {
     "command": "set numberwidth=3",
-    "description": "Sets width of the 'gutter' column used for numbering to 3"
+    "description": "Sets width of the 'gutter' column used for numbering to 3 (default 4)"
   },
   {
     "command": "set relativenumber",


### PR DESCRIPTION
Added 'set numberwidth=3' as an option in commands.json

numberwidth is an option to change the number of columns used for line number.

You can find out more about numberwidth [here](http://vim.wikia.com/wiki/Display_line_numbers).