### PR TITLE
Fix noerrorbells and novisualbell typo

### DIFF
--- a/src/vim-commands.json
+++ b/src/vim-commands.json
@@ -62,10 +62,10 @@
   "set showmatch": {
     "description": "Show matching brackets when text indicator is over them"
   },
-  "set noerrorbell": {
+  "set noerrorbells": {
     "description": "Silence the error bell"
   },
-  "set novisualbells": {
+  "set novisualbell": {
     "description": "Visually hide the error bell"
   },
   "set foldcolumn=1": {


### PR DESCRIPTION
Neovim complained about novisualbell when I added in my settings. I found out the two bell commands actually had opposite `s`s

https://vim.fandom.com/wiki/Disable_beeping

ty for the quick setup by the way